### PR TITLE
Output to a single file specified by `--file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,25 @@ There are a number of options available to the user. The first two are
 required, the rest are not:
 
 ```
--a, --address: the address you wish to monitor for incoming transactions [required]
--c, --currency: the target fiat currency you are using to account in [required]
--b, --btcex: the exchange you wish to use to get the price of FCT in BTC (defaults to CryptoCompare Current Aggregate)
--x, --fiatex: the exchange you wish to use to get the price of BTC in your target currency (defaults to CryptoCompare Current Aggregate)
--H, --host: the IP address of your walletd host (default localhost)
--P, --port: the port of your walletd host (default 8089)
--p, --path: path to output CSV to an additional location (note: factoid-address-monitord will always save the master copy of the CSV to the local folder)
--k, --key: your bitcoin.tax API key
--S, --secret: your bitcoin.tax API secret
--t, --type: your bitcoin.tax transaction type (defaults to 'income' - check the bitcoin.tax API documentation for more options)
+Options:
+  --version       Show version number                                  [boolean]
+  --address, -a   The address you would like to monitor               [required]
+  --currency, -c  The currency you are accounting in, given as three letter code
+                  (e.g. USD, GBP, EUR)                                [required]
+  --btcex, -b     The exchange you wish to use to get the price of FCT in BTC.
+                  Defaults to Cryptocompare Current Aggregate[default: "CCCAGG"]
+  --fiatex, -x    The exchange you wish to use to get the price of BTC in your
+                  chosen currency. Defaults to Cryptocompare Current Aggregate
+                                                             [default: "CCCAGG"]
+  --host, -H      The IP of your walletd host. Defaults to localhost
+                                                          [default: "localhost"]
+  --port, -P      The port to access walletd. Defaults to 8089   [default: 8089]
+  --file, -f      CSV file to output and track transaction history    [required]
+  --key, -k       Your bitcoin.tax key
+  --secret, -S    Your bitcoin.tax secret
+  --type, -t      Your bitcoin.tax transaction type. Defaults to `income`. See
+                  the bitcoin.tax API docs for details       [default: "Income"]
+  --help, -h      Show help                                            [boolean]
 ```
 
 #### Without PM2 or Systemd
@@ -102,18 +111,17 @@ Finally, you can also use PM2. PM2 is a daemon management tool built primarily f
 
 #### Master csv
 
-The master copy of transaction-history.csv lives in the project directory. That
-csv is used to store the current state and to prevent duplicates. Some people
-may want to edit the csv file. For example, they might want to delete all
-transactions they have already exported to Excel so that they can see clearly
-any new transactions that have arrived.
+The CSV pointed to by `--file` is used to store the current state and to
+prevent duplicates. Some people may want to edit the csv file. For example,
+they might want to delete all transactions they have already exported to Excel
+so that they can see clearly any new transactions that have arrived.
 
-Editing the master copy of transaction-csv will not work. Instead, it would
-lead to deleted transactions being imported again, and thus duplicates
-occurring in your Excel records or in your bitcoin.tax account. If you want to
-edit the csv file directly, specify a path for a new file using `-p`. You can
-edit that copy directly without fear of creating duplicate transactions in your
-records.
+If you wish to do this copy the file and edit the copy instead of editing the
+file directly.
+
+Editing the main CSV will not work. Instead, it would lead to deleted
+transactions being imported again, and thus duplicates occurring in your Excel
+records or in your bitcoin.tax account.
 
 #### Price
 

--- a/SYSTEMD.md
+++ b/SYSTEMD.md
@@ -19,17 +19,15 @@ script. Again, this could just be the path where you cloned this project.  If
 the dependencies were installed globally and you copied the script to
 `/usr/bin` it would look like this.
 ```
-ExecStart=/usr/bin/factoid-address-monitord --address %I $FACTOID_ADDRESS_MONITORD_OPTS
+ExecStart=/usr/bin/factoid-address-monitord --address %I --file /var/db/factoid-address-monitord/%I.csv $FACTOID_ADDRESS_MONITORD_OPTS
 ```
 
-### WorkingDirectory
-The unit uses the public Factoid address as the name of a directory where it
-stores the `transaction-history.csv`. By default the path is
-`/var/db/factoid-address-monitord/FAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/`.
-**You must create the directories before starting the service.**
-```
-WorkingDirectory=/var/db/factoid-address-monitord/%I
-```
+### Output directory
+The unit uses the public Factoid address as the name of the CSV file where it
+stores the transaction history. By default the path is
+`/var/db/factoid-address-monitord/`.
+**You must create this directories before starting the service.**
+The path can be changed by editing the `ExecStart` line above.
 
 ### Additional options
 To pass additional CLI options you can create a file
@@ -44,7 +42,7 @@ FACTOID_ADDRESS_MONITORD_OPTS="--currency USD --key xxxxxxxxx --secret xxxxxxxxx
 cp /path/to/factoid-address-monitord.defaults /etc/default/factoid-address-monitord
 cp /path/to/factoid-address-monitord@.service /etc/systemd/system/
 systemctl daemon-reload
-mkdir -p /var/db/factoid-address-monitord/FA2efw5fsufKusByeBVa6gZERKV9X5LJN3wKcazndTQNFAePRrft
+mkdir -p /var/db/factoid-address-monitord/
 ```
 
 ## Starting

--- a/factoid-address-monitord
+++ b/factoid-address-monitord
@@ -43,10 +43,10 @@ const argv = yargs
             describe: 'The port to access walletd. Defaults to 8089',
             default: 8089
         },
-        path: {
-            demand: false,
-            alias: 'p',
-            describe: 'Path to output an additional copy of transaction-history.csv (note: factoid-address-monitord will always save the master copy of the CSV to the working directory)'
+        file: {
+            demand: true,
+            alias: 'f',
+            describe: 'CSV file to output transaction history'
         },
         key: {
             demand: false,
@@ -61,7 +61,7 @@ const argv = yargs
         type: {
             demand: false,
             alias: 't',
-            describe: 'You bitcoin.tax transaction type. Defaults to `income`. See the bitcoin.tax API docs for details',
+            describe: 'Your bitcoin.tax transaction type. Defaults to `income`. See the bitcoin.tax API docs for details',
             default: 'Income'
         },
     })
@@ -125,10 +125,7 @@ async function handleNewTransactions(receivedTransactions) {
     try {
         for (const item of receivedTransactions) {
             const csvData = `${item.date.slice(0, 10)}, ${argv.address}, ${item.txid}, ${item.fctReceived}, ${item.txType}, ${item.btcExchange}, ${item.fiatExchange}, ${item.fiatPrice}, ${item.fiatValue}, ${item.currency}\n`;
-            fs.appendFileSync('transaction-history.csv', csvData);
-            if (argv.path !== undefined) {
-                fs.appendFileSync(`${argv.path}/transaction-history.csv`, csvData);
-            }
+            fs.appendFileSync(`${argv.file}`, csvData);
         }
         console.log('Written new transaction(s) to csv');
 
@@ -205,8 +202,8 @@ function wait(timeout) {
 
 async function getFileState() {
     const currentFileState = new Set();
-    if (fs.existsSync('./transaction-history.csv')) {
-        const csvFilePath = './transaction-history.csv';
+    if (fs.existsSync(`${argv.file}`)) {
+        const csvFilePath = `${argv.file}`;
         await new Promise((resolve, reject) => {
             csv()
                 .fromFile(csvFilePath)
@@ -218,10 +215,7 @@ async function getFileState() {
     } else {
         console.log('Initialising new CSV');
         const csvInit = 'date, address, txid, fctReceived, txType, btcExchange, fiatExchange, fiatPrice, fiatValue, currency\n';
-        fs.writeFileSync('./transaction-history.csv', csvInit);
-        if (argv.path !== undefined) {
-            fs.writeFileSync(`${argv.path}/transaction-history.csv`, csvInit);
-        }
+        fs.writeFileSync(`${argv.file}`, csvInit);
         return currentFileState;
     }
 }
@@ -240,7 +234,7 @@ async function getTransactions(x) {
 
 // async function test() {
 //     try {
-//         fs.unlinkSync('./transaction-history.csv');
+//         fs.unlinkSync(`${argv.file}`);
 //     } catch (err) {
 //         console.log('No file to delete');
 //     }

--- a/factoid-address-monitord
+++ b/factoid-address-monitord
@@ -46,7 +46,7 @@ const argv = yargs
         file: {
             demand: true,
             alias: 'f',
-            describe: 'CSV file to output transaction history'
+            describe: 'CSV file to output and track transaction history'
         },
         key: {
             demand: false,

--- a/factoid-address-monitord@.service
+++ b/factoid-address-monitord@.service
@@ -7,18 +7,15 @@ Description=Monitor transactions for Factoid address %I
 ;After=factom-walletd.service
 
 [Service]
-; Set the directory where the transaction data is stored. This directory must
-; exist, including a directory by the name of the public factoid address.
-WorkingDirectory=/var/db/factoid-address-monitord/%I
-
 ; Set this to the node_modules folder with the depencies installed.
 Environment="NODE_PATH=/usr/lib/node_modules/"
 
 ; Set additional CLI opts in this optional file.
 EnvironmentFile=-/etc/default/factoid-address-monitord
 
-; Set the path to the factoid-address-monitord script.
-ExecStart=/usr/bin/factoid-address-monitord --address %I $FACTOID_ADDRESS_MONITORD_OPTS
+; Set the path to the factoid-address-monitord script and the output directory
+; for CSV files.
+ExecStart=/usr/bin/factoid-address-monitord --address %I --file /var/db/factoid-address-monitord/%I.csv $FACTOID_ADDRESS_MONITORD_OPTS
 
 Restart=always
 


### PR DESCRIPTION
Outputting to a file in the working directory is atypical behavior for a daemon. Instead make `--file` a required option and use this as a full path to a file to output the CSV. This also allows the user to control what the CSV is named. 

When used with the systemd service it changes the output from `/var/db/factoid-address-monitord/FA3fFRFvm1ndnpekXvFCr5Cw47mdxPyfHnYsLTGYVL5qMxgvjpNg/transaction-history.csv` to `/var/db/factoid-address-monitord/FA3fFRFvm1ndnpekXvFCr5Cw47mdxPyfHnYsLTGYVL5qMxgvjpNg.csv`.

Documentation and help output is updated to reflect these changes as well.