### PR TITLE
Fixed factomd host/port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ First, fill out the location of your factomd node. Default is localhost on port 
 
 ```
  "factomdConfig": {
-    "host": "localhost",
-    "port": 8088
+    "factomdHost": "localhost",
+    "factomdPort": 8088
 },
 ```
 


### PR DESCRIPTION
I looked at the code, and, unless I'm misunderstanding something, I think the docs were off just a bit.